### PR TITLE
Debugger setup

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "node",
+        "request": "attach",
+        "name": "Launch Program",
+        "skipFiles": ["<node_internals>/**"],
+        "port": 9229
+      }
+    ]
+  }
+  

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "type-check": "tsc"
+    "type-check": "tsc",
+    "dev:debug": "NODE_OPTIONS='--inspect' next dev"
   },
   "dependencies": {
     "@apollo/client": "^3.3.19",


### PR DESCRIPTION
Using `yarn dev:debug` should allow you to use debugger breakpoints and use the dev tools in chrome
like you would a non ssr frontend app.

![image](https://user-images.githubusercontent.com/26678464/120116977-c2c93a00-c13f-11eb-8786-9bccf19fd514.png)
