### PR TITLE
Dynamic Themes and Local Cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@apollo/client": "^3.3.19",
     "@hookform/resolvers": "^2.5.2",
     "@material-ui/core": "^4.11.4",
+    "@reduxjs/toolkit": "^1.6.0",
     "@types/graphql": "^14.5.0",
     "@types/next-seo": "^2.1.2",
     "@types/nprogress": "^0.2.0",

--- a/src/components/shell/Shell.tsx
+++ b/src/components/shell/Shell.tsx
@@ -10,7 +10,6 @@ import styled, { createGlobalStyle, ThemeProvider } from "styled-components";
 import ws from "ws";
 
 import NoSsr from "../../library/ssr/NoSsr";
-import { DarkTheme } from "../../library/theme";
 import { AuthResourceReducerAction, getAuthenticationToken } from "../../store/authResourceReducer";
 import { selectDerivedTheme } from "../../store/dynamicThemeReducer";
 import store from "../../store/store";

--- a/src/components/shell/Shell.tsx
+++ b/src/components/shell/Shell.tsx
@@ -12,6 +12,7 @@ import ws from "ws";
 import NoSsr from "../../library/ssr/NoSsr";
 import { DarkTheme } from "../../library/theme";
 import { AuthResourceReducerAction, getAuthenticationToken } from "../../store/authResourceReducer";
+import { selectDerivedTheme } from "../../store/dynamicThemeReducer";
 import store from "../../store/store";
 
 type ShellProperties = {
@@ -117,6 +118,7 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
 });
 
 export const Shell: FC<ShellProperties> = ({ children }: ShellProperties) => {
+    const derivedTheme = useSelector(selectDerivedTheme);
 
     // get the authentication token from local storage if it exists
     const authToken = useSelector(getAuthenticationToken);
@@ -170,7 +172,7 @@ export const Shell: FC<ShellProperties> = ({ children }: ShellProperties) => {
     });
 
     return (
-        <ThemeProvider theme={DarkTheme}>
+        <ThemeProvider theme={derivedTheme}>
             <ApolloProvider client={client}>
                 <GlobalStyle />
                 <Head>

--- a/src/library/theme.ts
+++ b/src/library/theme.ts
@@ -35,7 +35,6 @@ export const DarkTheme: DefaultTheme = {
     }
 };
 
-
 export const LightTheme: DefaultTheme = {
     borderRadius: "0px",
     palette: {
@@ -69,4 +68,50 @@ export const LightTheme: DefaultTheme = {
         two: 1265,
         three: 1336
     }
+};
+
+export const PreDefinedThemes = {
+    DarkTheme, LightTheme
+};
+
+export const themeSerializer = (theme: DefaultTheme): string => JSON.stringify(theme, undefined, 4);
+export const themeDeserializer = (theme: string): DefaultTheme => JSON.parse(theme);
+
+/**
+ * Ensures that passed-in theme sets contain
+ * all the properties from the default theme.
+ * It is used for validation when inputting new themes. 
+ * It currently does not validate styled property values.
+ */
+export const validateThemeContainsKeys = (theme: DefaultTheme, defaultThemeObject = DarkTheme): boolean => {
+
+    /**
+     * Converts all nested and root level properties
+     * into a flat array of keys using recursion.
+     * @example {key: {nestedProp: ""}} => ["key", "key.nestedProp"]
+     */
+    const keyify = (object: DefaultTheme, prefix = ""): Array<string> =>
+        // eslint-disable-next-line unicorn/no-array-reduce
+        Object.keys(object).reduce((results, element) => {
+            if (Array.isArray(object[element])) {
+                return results;
+            } else if (typeof object[element] === "object" && object[element] !== null) {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                return [...results, ...keyify(object[element], prefix + element + ".")];
+            }
+            return [...results, prefix + element];
+        }, []);
+
+    const passedInThemeKeys = keyify(theme);
+    const defaultThemeObjectKeys = keyify(defaultThemeObject);
+
+    const isInsidePassedInKeys = (currentValue: string) => passedInThemeKeys.includes(currentValue);
+
+    /** Checking that the passed in theme contains all of the 
+     * keys that exist in the default theme. And making sure 
+     * that the keys are of the same length. There should be
+     * no more and no less keys than in the default theme. 
+     */
+    return defaultThemeObjectKeys.every((element) => isInsidePassedInKeys(element))
+        && passedInThemeKeys.length === defaultThemeObjectKeys.length;
 };

--- a/src/library/theme.ts
+++ b/src/library/theme.ts
@@ -1,3 +1,5 @@
+import * as yup from "yup";
+
 import { DefaultTheme } from "styled-components";
 
 export const DarkTheme: DefaultTheme = {
@@ -77,41 +79,69 @@ export const PreDefinedThemes = {
 export const themeSerializer = (theme: DefaultTheme): string => JSON.stringify(theme, undefined, 4);
 export const themeDeserializer = (theme: string): DefaultTheme => JSON.parse(theme);
 
+
+type ValidateThemeReturnValue = Readonly<{
+    success: boolean
+    error?: Error
+}>
 /**
  * Ensures that passed-in theme sets contain
  * all the properties from the default theme.
  * It is used for validation when inputting new themes. 
  * It currently does not validate styled property values.
  */
-export const validateThemeContainsKeys = (theme: DefaultTheme, defaultThemeObject = DarkTheme): boolean => {
-
-    /**
-     * Converts all nested and root level properties
-     * into a flat array of keys using recursion.
-     * @example {key: {nestedProp: ""}} => ["key", "key.nestedProp"]
-     */
-    const keyify = (object: DefaultTheme, prefix = ""): Array<string> =>
-        // eslint-disable-next-line unicorn/no-array-reduce
-        Object.keys(object).reduce((results, element) => {
-            if (Array.isArray(object[element])) {
-                return results;
-            } else if (typeof object[element] === "object" && object[element] !== null) {
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                return [...results, ...keyify(object[element], prefix + element + ".")];
-            }
-            return [...results, prefix + element];
-        }, []);
-
-    const passedInThemeKeys = keyify(theme);
-    const defaultThemeObjectKeys = keyify(defaultThemeObject);
-
-    const isInsidePassedInKeys = (currentValue: string) => passedInThemeKeys.includes(currentValue);
-
-    /** Checking that the passed in theme contains all of the 
-     * keys that exist in the default theme. And making sure 
-     * that the keys are of the same length. There should be
-     * no more and no less keys than in the default theme. 
-     */
-    return defaultThemeObjectKeys.every((element) => isInsidePassedInKeys(element))
-        && passedInThemeKeys.length === defaultThemeObjectKeys.length;
+export const validateThemeContainsKeys = async (theme: DefaultTheme): Promise<ValidateThemeReturnValue> => {
+    try {
+        await validation.validate(theme, {abortEarly: false});
+        return  {
+            success: true,
+            error: undefined
+        };
+    } catch (error) {
+       
+        return {
+            success: false,
+            error: error
+        };
+    }
 };
+
+
+
+export const validation = yup.object().shape({
+    borderRadius: yup.string().required(),
+    palette: yup.object().shape({
+        primary: yup.object().shape({
+            100: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+            200: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+            300: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+            400: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+            500: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+            600: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+            700: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+            800: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+            900: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+        }),
+        accent:yup.object().shape({
+            default: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+            disabled: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+            hover: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+        }),
+        secondary:  yup.object().shape({
+            default: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+            washedOut: yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),
+        }),
+        buttonText:yup.string().required().matches(/^#([\da-f]{3}|[\da-f]{6})$/i),   
+
+    }),
+    animation: yup.object().shape({
+
+        micro: yup.string().required(),
+    }),
+    breakpoints: yup.object().shape({
+        one: yup.number().positive().integer().required(),
+        two:yup.number().positive().integer().required(),
+        three: yup.number().positive().integer().required(),
+
+    })
+});

--- a/src/library/theme.ts
+++ b/src/library/theme.ts
@@ -1,6 +1,5 @@
-import * as yup from "yup";
-
 import { DefaultTheme } from "styled-components";
+import * as yup from "yup";
 
 export const DarkTheme: DefaultTheme = {
     borderRadius: "8px",

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,19 +1,19 @@
-import { PreDefinedThemes, themeDeserializer, themeSerializer, validateThemeContainsKeys } from "../library/theme";
+import { NextSeo } from "next-seo";
 import React, { FC, useState } from "react";
-import { resetTheme, selectTheme, writeTheme } from "../store/dynamicThemeReducer";
-import styled, { useTheme } from "styled-components";
 import { useDispatch, useSelector } from "react-redux";
+import styled, { useTheme } from "styled-components";
 
 import { Button } from "../components/button/Button";
 import { FriendsList } from "../components/friends/FriendsList";
 import { Grid } from "../components/grid/Grid";
-import { Logo } from "../components/logo/Logo";
-import { NextSeo } from "next-seo";
-import { ProfileWidgetDataContainer } from "../components/user/ProfileWidget";
-import { ScheduleDataContainer } from "../components/schedule/Schedule";
 import { TextArea } from "../components/inputs/input";
-import store from "../store/store";
+import { Logo } from "../components/logo/Logo";
+import { ScheduleDataContainer } from "../components/schedule/Schedule";
+import { ProfileWidgetDataContainer } from "../components/user/ProfileWidget";
 import useMediaQuery from "../library/hooks/useMediaQuery";
+import { PreDefinedThemes, themeDeserializer, themeSerializer, validateThemeContainsKeys } from "../library/theme";
+import { resetTheme, selectTheme, writeTheme } from "../store/dynamicThemeReducer";
+import store from "../store/store";
 
 const Column = styled.div`
     margin-top: 30px;

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,0 +1,189 @@
+import { NextSeo } from "next-seo";
+import React from "react";
+import { useState } from "react";
+import { FC } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import styled, { useTheme } from "styled-components";
+
+import { Button } from "../components/button/Button";
+import { FriendsList } from "../components/friends/FriendsList";
+import { Grid } from "../components/grid/Grid";
+import { TextArea } from "../components/inputs/input";
+import { Logo } from "../components/logo/Logo";
+import { ScheduleDataContainer } from "../components/schedule/Schedule";
+import { ProfileWidgetDataContainer } from "../components/user/ProfileWidget";
+import useMediaQuery from "../library/hooks/useMediaQuery";
+import { PreDefinedThemes, themeDeserializer, themeSerializer, validateThemeContainsKeys } from "../library/theme";
+import { resetTheme, selectTheme, writeTheme } from "../store/dynamicThemeReducer";
+import store from "../store/store";
+
+
+const Column = styled.div`
+    margin-top: 30px;
+    display: grid;
+    grid-template-rows: 4rem 640px;
+    row-gap: 60px;
+`;
+
+const ThemeEditorBox = styled.div`
+    padding-top: 20px;
+    padding-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    width: 100%;
+    justify-content: center;
+`;
+
+const ThemeEditorButton = styled(Button)`
+    align-self: flex-end;
+`;
+
+const ThemeEditorActions = styled.div`
+    display: flex;
+    gap: 10px;
+    width: 100%;
+    justify-content: flex-end;
+`;
+
+const SettingTitle = styled.div`
+    display: block;
+    font-size: 2rem;
+    line-height: 3.1rem;
+    font-weight: 700;
+    padding-top: 0.5rem;
+    color: ${({ theme }) => theme.palette.primary[100]};
+`;
+
+
+const SettingsPage: FC = () => {
+
+    const theme = useTheme();
+    const dispatch = useDispatch();
+    const one = useMediaQuery(`(min-width:${theme.breakpoints.one + 1}px)`);
+    const two = useMediaQuery(`(min-width:${theme.breakpoints.two + 1}px)`);
+    const three = useMediaQuery(`(min-width:${theme.breakpoints.three + 1}px)`);
+    const predefinedSiteThemesKeys = Object.keys(PreDefinedThemes);
+
+    const reducerAppTheme = useSelector(selectTheme);
+
+    const [editorTheme, setEditorTheme] = useState(reducerAppTheme);
+    const [selectedPredefinedTheme, setPredefinedTheme] = useState("");
+    const [isThemeValid, setIsThemeValid] = useState(true);
+    /* Used to generate rows for the editor textarea */
+    const editorThemeNewLines = (editorTheme.match(/\n/g) || "").length + 1;
+
+
+    /**
+     * can change select value to one of the predefined themes
+     */
+    const handlePreDefinedThemeChange = (event) => {
+        const currentTargetValue = event.target.value;
+        if (predefinedSiteThemesKeys.includes(currentTargetValue)) {
+            setPredefinedTheme(currentTargetValue);
+            setEditorTheme(themeSerializer(PreDefinedThemes[currentTargetValue]));
+        }
+    };
+
+    const handleThemeSubmission = () => {
+        if (editorTheme !== reducerAppTheme) {
+            /**
+             * @TODO add styled-components schema 
+             * validation to check if all properties
+             * valid if they exist. Currently only checking
+             * for existence.
+             */
+            const isSubmittedThemeValid = validateThemeContainsKeys(themeDeserializer(editorTheme));
+
+            if (!isSubmittedThemeValid) {
+                setIsThemeValid(false);
+                return;
+            }
+
+
+            if (isSubmittedThemeValid) {
+                dispatch(writeTheme(editorTheme));
+            }
+        }
+    };
+
+    const handleResetTheme = () => {
+        dispatch(resetTheme());
+        setPredefinedTheme("");
+        setEditorTheme(store.getState().dynamicThemeReducer.theme);
+        // the default theme will always be valid
+        setIsThemeValid(true);
+    };
+
+    return <>
+        <NextSeo
+            defaultTitle="Dogehouse Revived"
+            title="Settings | Dogehouse Revived"
+            description="Taking voice conversations to the moon 🚀"
+            additionalLinkTags={[
+                {
+                    rel: "icon",
+                    href: "https://cdn.lvk.sh/dogehouse/logo.svg",
+                },
+                {
+                    rel: "apple-touch-icon",
+                    href: "https://cdn.lvk.sh/dogehouse/logo.svg",
+                    sizes: "76x76"
+                }
+            ]}
+        />
+        <Grid>
+            {
+                one &&
+                <Column>
+                    <Logo small={!three} />
+                    <FriendsList />
+                </Column>
+            }
+            <Column>
+                <div>
+                    <ProfileWidgetDataContainer />
+                    <ThemeEditorBox>
+                        <SettingTitle>Theme Editor</SettingTitle>
+                        {/* @TODO implement a bit of a nicer Error box. */}
+                        {!isThemeValid && (<p>Theme is not valid try to reset it or make sure all properties are accounted for.</p>)}
+                        <div style={{
+                            alignSelf: "flex-end"
+                        }}>
+                            <label>
+                                <p>Pick a pre-defined theme (optional):</p>
+                                <select style={{ width: "100%" }} value={selectedPredefinedTheme} onChange={handlePreDefinedThemeChange}>
+                                    <option value=''></option>
+                                    {predefinedSiteThemesKeys.map(item =>
+                                        <option key={item} value={item}>{item}</option>
+                                    )}
+                                </select>
+                            </label>
+                        </div>
+                        <TextArea
+                            onChange={event => setEditorTheme(event.target.value)}
+                            rows={editorThemeNewLines}
+                            style={{ width: "100%" }}
+                            value={editorTheme}
+                        />
+                        <ThemeEditorActions>
+                            <ThemeEditorButton onClick={handleResetTheme} variant="PRIMARY">Reset Theme</ThemeEditorButton>
+                            <ThemeEditorButton onClick={handleThemeSubmission} variant="ACCENT">Apply Theme</ThemeEditorButton>
+                        </ThemeEditorActions>
+                    </ThemeEditorBox>
+                </div>
+            </Column>
+            {
+                two &&
+                <Column>
+                    <div>
+                        <ProfileWidgetDataContainer />
+                        <ScheduleDataContainer />
+                    </div>
+                </Column>
+            }
+        </Grid>
+    </>;
+};
+
+export default SettingsPage;

--- a/src/store/dynamicThemeReducer.ts
+++ b/src/store/dynamicThemeReducer.ts
@@ -1,0 +1,29 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { DefaultTheme } from "styled-components";
+
+import { DarkTheme, themeDeserializer, themeSerializer } from "../library/theme";
+import { RootState } from "./store";
+
+const initialState = {
+    theme: themeSerializer(DarkTheme)
+};
+
+export const dynamicThemeSlice = createSlice({
+    name: "dynamicTheme",
+    initialState,
+    reducers: {
+        resetTheme: state => {
+            state.theme = themeSerializer(DarkTheme);
+        },
+        writeTheme: (state, action: PayloadAction<string>) => {
+            state.theme = action.payload;
+        }
+    }
+});
+
+export const { resetTheme, writeTheme } = dynamicThemeSlice.actions;
+
+export const selectTheme = (state: RootState): string => state.dynamicThemeReducer.theme;
+export const selectDerivedTheme = (state: RootState): DefaultTheme => themeDeserializer(state.dynamicThemeReducer.theme);
+
+export default dynamicThemeSlice.reducer;

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -3,6 +3,7 @@ import { persistReducer, persistStore } from "redux-persist";
 import storage from "redux-persist/lib/storage";
 
 import authResourceReducer from "./authResourceReducer";
+import dynamicThemeReducer from "./dynamicThemeReducer";
 
 /**
  * Only Whitelist Reducer groups we want 
@@ -11,8 +12,8 @@ import authResourceReducer from "./authResourceReducer";
 const persistedReducer = persistReducer({
     key: "root",
     storage,
-    whitelist: ["authResourceReducer"]
-}, combineReducers({ authResourceReducer }));
+    whitelist: ["authResourceReducer", "dynamicThemeReducer"]
+}, combineReducers({ authResourceReducer, dynamicThemeReducer }));
 
 const composeEnhancers = process.browser &&
     window["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] as typeof compose || compose;

--- a/yarn.lock
+++ b/yarn.lock
@@ -681,6 +681,16 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.14.0.tgz#c67fc20a4d891447ca1a855d7d70fa79a3533001"
   integrity sha512-sDOAZcYwynHFTbLo6n8kIbLiVF3a3BLkrmehJUyEbT9F+Smbi47kLGS2gG2g0fjBLR/Lr1InPD7kXL7FaTqEkw==
 
+"@reduxjs/toolkit@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.6.0.tgz#0a17c6941c57341f8b31e982352b495ab69d5add"
+  integrity sha512-eGL50G+Vj5AG5uD0lineb6rRtbs96M8+hxbcwkHpZ8LQcmt0Bm33WyBSnj5AweLkjQ7ZP+KFRDHiLMznljRQ3A==
+  dependencies:
+    immer "^9.0.1"
+    redux "^4.1.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz#a21117b19ee9be70c379ec1877537ef2e1c63301"
@@ -3156,6 +3166,11 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+immer@^9.0.1:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.3.tgz#146e2ba8b84d4b1b15378143c2345559915097f4"
+  integrity sha512-mONgeNSMuyjIe0lkQPa9YhdmTv8P19IeHV0biYhcXhbd5dhdB9HSK93zBpyKjp6wersSUgT5QyU0skmejUVP2A==
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -4846,6 +4861,11 @@ redux-persist@^6.0.0:
   resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
   integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
 
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
 redux@^4.0.0, redux@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.0.tgz#eb049679f2f523c379f1aff345c8612f294c88d4"
@@ -4885,6 +4905,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 reserved-words@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
# Dynamic Theming
This change allows for users to theme their own web clients. 
We utilize a Redux store to feed the active theme to the `Shell` 
component and have DarkTheme as a fallback using the reset.

These theme changes are locally cached using the redux-persist
whitelist. And we are currently validating that all the properties from
the default style are included in new user themes. 

Users are also able to select from a list of team defined themes
that they can apply in place of their own. 

Some current todos are
- [x] `Yup` form validation to simplify theme updates
- [x]  Potential CSS or Styled-Components properties validation

> Me and Zibidimi are actively adding improvements 
> so this is kind of a live PR would appreciate feedback
> of the immediate code. Any out of scope improvements
> can be made into a follow up.

### Screenshot of Custom Theme
<img width="1214" alt="Screen Shot 2021-06-12 at 3 41 03 PM" src="https://user-images.githubusercontent.com/26678464/121790482-a6dc8400-cb94-11eb-9537-2cd0e845a92d.png">

### Screenshot of Predefined Theme Use
<img width="1239" alt="Screen Shot 2021-06-12 at 3 42 33 PM" src="https://user-images.githubusercontent.com/26678464/121790504-cffd1480-cb94-11eb-8768-a74d0b530775.png">

### Reseting to Dark Theme after pressing Reset Theme button
<img width="1201" alt="Screen Shot 2021-06-12 at 3 42 52 PM" src="https://user-images.githubusercontent.com/26678464/121790505-dbe8d680-cb94-11eb-94ad-d3921417dcf7.png">



